### PR TITLE
削除機能の追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order("created_at DESC")
@@ -34,6 +34,13 @@ class ItemsController < ApplicationController
       redirect_to root_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if current_user.id == @item.user_id
+      @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,6 +41,8 @@ class ItemsController < ApplicationController
     if current_user.id == @item.user_id
       @item.destroy
       redirect_to root_path
+    elsif current_user.id != @item.user_id
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
     if current_user.id == @item.user_id
       @item.destroy
       redirect_to root_path
-    elsif current_user.id != @item.user_id
+    else current_user.id != @item.user_id
       redirect_to root_path
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
     if current_user.id == @item.user_id
       @item.destroy
       redirect_to root_path
-    else current_user.id != @item.user_id
+    else
       redirect_to root_path
     end
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
     <% else %>
       <% if user_signed_in? && current_user.id != @item.user_id %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   root to: "items#index"
-  resources :items, only: [:new, :create, :show, :edit,:update]
+  resources :items, only: [:new, :create, :show, :edit,:update, :destroy]
 end


### PR DESCRIPTION
#What
今回はログイン状態のユーザーが自身の商品を削除できる機能を追加
また、showのビューファイルでログイン状態のユーザーと商品を出品しているユーザーが一致しているかどうか
条件分岐は記載しているが、念のために、コントローラーにも、ログインしているユーザーと、商品を出品しているユーザーが
一致しているか検証して、trueなら削除を実行してトップページに遷移できるようにした

#Why
理由は万が一、商品を削除したくなった時に、削除機能があった方が便利な為。また、セキュリティを考慮して、二重で
商品を出品しているユーザーと一致しているか記載をした。

削除が成功するURL
https://gyazo.com/beeed70cf1672b0d57034a1970978ec8